### PR TITLE
Remove extraneous ALLOWED_HOSTS print

### DIFF
--- a/poemgenerator/settings.py
+++ b/poemgenerator/settings.py
@@ -40,8 +40,6 @@ ALLOWED_HOSTS = env.list('ALLOWED_HOSTS', default=[
     '.ngrok-free.app',
 ])
 
-# Debug: print ALLOWED_HOSTS to verify
-print(f"ALLOWED_HOSTS: {ALLOWED_HOSTS}")
 
 CSRF_TRUSTED_ORIGINS = [
     'https://gedichtgpt.nl',


### PR DESCRIPTION
## Summary
- remove debug logging of `ALLOWED_HOSTS`

## Testing
- `python -m py_compile poemgenerator/settings.py`


------
https://chatgpt.com/codex/tasks/task_e_683f52155d18832592ba8a14ab13f164