### PR TITLE
Add redirect URLs to limit errors and new CTA link

### DIFF
--- a/poems/templates/poems/create_poem.html
+++ b/poems/templates/poems/create_poem.html
@@ -165,6 +165,7 @@
                 <div id="retry-info" class="mt-2 text-sm text-red-500 hidden">
                     Het systeem probeert het automatisch opnieuw... Even geduld.
                 </div>
+                <div id="error-link" class="mt-2 text-sm hidden"></div>
             </div>
         </section>
 
@@ -316,6 +317,7 @@
             const errorDiv = document.getElementById('error');
             const errorMessage = document.getElementById('error-message');
             const retryInfo = document.getElementById('retry-info');
+            const errorLink = document.getElementById('error-link');
             const poemDiv = document.getElementById('poem');
             const imageContainer = document.getElementById('image-container');
             const submitButton = document.querySelector('button[type="submit"]');
@@ -324,6 +326,8 @@
             result.classList.add('hidden');
             errorDiv.classList.add('hidden');
             retryInfo.classList.add('hidden');
+            errorLink.classList.add('hidden');
+            errorLink.innerHTML = '';
             imageContainer.innerHTML = '';
             loading.classList.add('active');
             submitButton.disabled = true;
@@ -366,7 +370,10 @@
                 } else {
                     errorMessage.textContent = responseData.message || 'Er is een fout opgetreden.';
                     errorDiv.classList.remove('hidden');
-                    if (response.status === 429 || response.status === 402) {
+                    if (responseData.redirect_url) {
+                        errorLink.innerHTML = `<a href="${responseData.redirect_url}" class="text-indigo-600 underline">Klik hier om verder te gaan</a>`;
+                        errorLink.classList.remove('hidden');
+                    } else if (response.status === 429 || response.status === 402) {
                         retryInfo.classList.remove('hidden');
                     }
                 }

--- a/poems/views.py
+++ b/poems/views.py
@@ -3,7 +3,7 @@ import json
 from django.shortcuts import render
 from django.http import JsonResponse
 from django.conf import settings
-from django.urls import reverse_lazy
+from django.urls import reverse, reverse_lazy
 from django.views.generic import CreateView, View
 from django_ratelimit.decorators import ratelimit
 from django.utils.decorators import method_decorator
@@ -272,14 +272,22 @@ class PoemCreateView(View):
                 if poem_count >= 2:
                     # Check of er credits zijn
                     if user.profile.credits < 1:
-                        return JsonResponse({'status': 'error', 'message': 'Je hebt je gratis maandlimiet bereikt. Koop credits om meer gedichten te genereren.'}, status=402)
+                        return JsonResponse({
+                            'status': 'error',
+                            'message': 'Je hebt je gratis maandlimiet bereikt. Koop credits om meer gedichten te genereren.',
+                            'redirect_url': reverse('purchase_credits')
+                        }, status=402)
                     # Trek 1 credit af als straks opslaan slaagt.
             else:
                 # Anoniem: limit per dag (24 uur)
                 past_24h = now - timedelta(days=1)
                 poems_count = Poem.objects.filter(ip_address=ip_address, created_at__gte=past_24h).count()
                 if poems_count >= 2:
-                    return JsonResponse({'status': 'error', 'message': 'Je hebt het maximale aantal gedichten (2) voor vandaag bereikt. Maak een account en koop credits om meer te genereren.'}, status=429)
+                    return JsonResponse({
+                        'status': 'error',
+                        'message': 'Je hebt het maximale aantal gedichten (2) voor vandaag bereikt. Maak een account en koop credits om meer te genereren.',
+                        'redirect_url': reverse('signup')
+                    }, status=429)
 
             # Genereer het gedicht
             structured_input = _process_user_input(data)


### PR DESCRIPTION
## Summary
- add `redirect_url` to 402/429 JSON responses in `PoemCreateView.post`
- insert link container in error block and handle link via JS
- hide retry message when `redirect_url` exists

## Testing
- `python manage.py check`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_683f5c87615483259a5735b5cc887097